### PR TITLE
Switch to cached database for routing import

### DIFF
--- a/xc/common/utils/prjxray_routing_import.py
+++ b/xc/common/utils/prjxray_routing_import.py
@@ -40,6 +40,7 @@ import functools
 import pickle
 
 import sqlite3
+from prjxray_db_cache import DatabaseCache
 
 now = datetime.datetime.now
 
@@ -1323,8 +1324,7 @@ def main():
     if synth_tiles is None:
         synth_tiles = find_constant_network(graph)
 
-    with sqlite3.connect("file:{}?mode=ro".format(args.connection_database),
-                         uri=True) as conn:
+    with DatabaseCache(args.connection_database, read_only=True) as conn:
 
         populate_bufg_rebuf_map(conn)
 


### PR DESCRIPTION
Signed-off-by: Andrew Butt <butta@seas.upenn.edu>

On our hard drive based storage system, this change decreases the runtime of the import graph nodes step of routing import from over an hour to under 2 minutes.