### PR TITLE
xc: xc7: fix AD1MUX inputs to avoid conflicting bits

### DIFF
--- a/xilinx/common/primitives/slicem/slicem.pb_type.xml
+++ b/xilinx/common/primitives/slicem/slicem.pb_type.xml
@@ -400,6 +400,26 @@
         </metadata>
       </pb_type>
 
+      <pb_type name="ADI1MUX_ROUTING" num_pb="1">
+        <input name="BI" num_pins="1"/>
+        <input name="STUB" num_pins="1"/>
+        <input name="AI" num_pins="1"/>
+        <output name="DI1" num_pins="1"/>
+        <mode name="default">
+          <interconnect>
+            <mux input="ADI1MUX_ROUTING.BI ADI1MUX_ROUTING.STUB ADI1MUX_ROUTING.AI" name="ADI1MUX" output="ADI1MUX_ROUTING.DI1">
+              <metadata>
+                <meta name="fasm_mux">
+                  ADI1MUX_ROUTING.BI = ALUT.DI1MUX.BDI1_BMC31
+                  ADI1MUX_ROUTING.STUB = ALUT.DI1MUX.BDI1_BMC31
+                  ADI1MUX_ROUTING.AI = ALUT.DI1MUX.AI
+                </meta>
+              </metadata>
+            </mux>
+          </interconnect>
+        </mode>
+      </pb_type>
+
       <pb_type name="BDI1MUX_ROUTING" num_pb="1">
         <input name="DI" num_pins="1"/>
         <input name="STUB" num_pins="1"/>
@@ -538,17 +558,12 @@
         <direct input="SLICEM_MODES.BI" name="BDI1MUX_ROUTING.BI" output="BDI1MUX_ROUTING.BI"/>
         <direct input="BDI1MUX_ROUTING.DI1" name="BDI1MUX_ROUTING.DI1" output="B_DRAM.DI1"/>
 
-        <mux name="ADI1MUX" input="BDI1MUX_ROUTING.DI1 DI64_STUB[2].DO SLICEM_MODES.BI SLICEM_MODES.AI" output="A_DRAM.DI1">
-          <metadata>
-            <meta name="fasm_mux">
-              BDI1MUX_ROUTING.DI1 = ALUT.DI1MUX.BDI1_BMC31,BLUT.DI1MUX.DI_CMC31
-              DI64_STUB[2].DO = ALUT.DI1MUX.BDI1_BMC31
-              SLICEM_MODES.BI = ALUT.DI1MUX.BDI1_BMC31,BLUT.DI1MUX.BI
-              SLICEM_MODES.AI = ALUT.DI1MUX.AI
-            </meta>
-          </metadata>
-          <pack_pattern in_port="DI64_STUB[2].DO" name="DRAM_DP" out_port="A_DRAM.DI1" />
-        </mux>
+        <direct input="SLICEM_MODES.AI" name="ADI1MUX_ROUTING.AI" output="ADI1MUX_ROUTING.AI"/>
+        <direct input="DI64_STUB[2].DO" name="ADI1MUX_ROUTING.DO" output="ADI1MUX_ROUTING.STUB">
+          <pack_pattern in_port="DI64_STUB[2].DO" name="DRAM_DP" out_port="ADI1MUX_ROUTING.STUB"/>
+        </direct>
+        <direct input="BDI1MUX_ROUTING.DI1" name="B_TO_A_DI1MUX_ROUTING.DI1" output="ADI1MUX_ROUTING.BI"/>
+        <direct input="ADI1MUX_ROUTING.DI1" name="ADI1MUX_ROUTING.DI1" output="A_DRAM.DI1"/>
 
         <!-- DI2 inputs -->
         <direct name="D_DI2" input="SLICEM_MODES.DX" output="D_DRAM.DI2" />

--- a/xilinx/xc7/tests/dram/CMakeLists.txt
+++ b/xilinx/xc7/tests/dram/CMakeLists.txt
@@ -6,6 +6,7 @@ function(dram_tests dram_num_instances dram_mode block_type_usage disable_vivado
   #    dram_num_instanes <instances_number>
   #    dram_mode <mode>
   #    block_type_usage <usage>
+  #    disable_vivado <flag>
   #   )
   # ~~~
   #
@@ -19,6 +20,8 @@ function(dram_tests dram_num_instances dram_mode block_type_usage disable_vivado
   # the usage of block types, e.g: SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=2
   # It is used as a reference to compare with block usage of implemented design
   # in ASSERT_BLOCK_TYPES_ARE_USED tests
+  #
+  # DISABLE_VIVADO defines if a given test should be skipped for vendor target
   #
   add_file_target(FILE dram_${dram_num_instances}_${dram_mode}.v SCANNER_TYPE verilog)
   add_fpga_target(
@@ -44,7 +47,7 @@ function(dram_tests dram_num_instances dram_mode block_type_usage disable_vivado
 
 endfunction()
 
-dram_tests(4 32x1s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1)
+dram_tests(4 32x1s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1 false)
 # Design uses 8 RAM32X1S primitives. Each primitive occupy 1 LUT and
 # there are 4 LUTs per SLICE so 2 SLICEM are required
 dram_tests(8 32x1s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=2 false)

--- a/xilinx/xc7/tests/dram/CMakeLists.txt
+++ b/xilinx/xc7/tests/dram/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(test_dram_packing)
 
-function(dram_tests dram_num_instances dram_mode block_type_usage)
+function(dram_tests dram_num_instances dram_mode block_type_usage disable_vivado)
   # ~~~
   # DRAM_TESTS(
   #    dram_num_instanes <instances_number>
@@ -30,10 +30,12 @@ function(dram_tests dram_num_instances dram_mode block_type_usage)
     EXPLICIT_ADD_FILE_TARGET
     )
 
-  add_vivado_target(
-    NAME dram_${dram_num_instances}_${dram_mode}_vivado
-    PARENT_NAME dram_${dram_num_instances}_${dram_mode}
+  if (NOT ${disable_vivado} STREQUAL "true")
+    add_vivado_target(
+      NAME dram_${dram_num_instances}_${dram_mode}_vivado
+      PARENT_NAME dram_${dram_num_instances}_${dram_mode}
     )
+  endif()
 
   add_dependencies(test_dram_packing
     dram_${dram_num_instances}_${dram_mode}_bit
@@ -45,13 +47,13 @@ endfunction()
 dram_tests(4 32x1s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1)
 # Design uses 8 RAM32X1S primitives. Each primitive occupy 1 LUT and
 # there are 4 LUTs per SLICE so 2 SLICEM are required
-dram_tests(8 32x1s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=2)
-dram_tests(2 32x1d SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1)
-dram_tests(4 32x2s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1)
-dram_tests(2 64x1d SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1)
-dram_tests(4 64x1s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1)
-dram_tests(2 128x1s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1)
-dram_tests(1 128x1d SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1)
-dram_tests(1 256x1s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1)
-dram_tests(1 32m SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1)
-dram_tests(1 64m SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1)
+dram_tests(8 32x1s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=2 false)
+dram_tests(2 32x1d SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1 false)
+dram_tests(4 32x2s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1 false)
+dram_tests(2 64x1d SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1 false)
+dram_tests(4 64x1s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1 false)
+dram_tests(2 128x1s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1 false)
+dram_tests(1 128x1d SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1 false)
+dram_tests(1 256x1s SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1 false)
+dram_tests(1 32m SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1 true)
+dram_tests(1 64m SYN-OUTPAD=17,SYN-INPAD=18,BLK-TL-SLICEM=1 false)


### PR DESCRIPTION
This fixes a situation for which the `ADI1MUX` in `SLICEMs`, when in `DRAM64` mode, could have an input directly connected to the `BI` `SLICEM` input port, therefore bypassing the `BDI1MUX` routing bel, causing a potential conflict in case the `BDI1MUX` was connected to something else than `BI`

This would fix https://github.com/chipsalliance/fpga-tool-perf/issues/444

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

