### PR TITLE
Add (no-op) `SIM_DEVICE` parameter to xc7 `BUFGCE`.

### DIFF
--- a/xilinx/xc7/techmap/cells_map.v
+++ b/xilinx/xc7/techmap/cells_map.v
@@ -3317,6 +3317,7 @@ module BUFGCE (
   input CE,
   output O,
   );
+  parameter SIM_DEVICE = "7SERIES";
 
   BUFGCTRL _TECHMAP_REPLACE_ (
     .O(O),


### PR DESCRIPTION
Ibex synthesis in [yosys-systemverilog][ysv-ibex-makefile] using F4PGA toolchain & arch-defs and latest Yosys fails with the following error:
```
${YSV_REPO}/UHDM-integration-tests/env/symbiflow/share/f4pga/techmaps/xc7_vpr/techmap/cells_map.v:0: ERROR: Can't find object for defparam `SIM_DEVICE`!
Traceback (most recent call last):
  File "${YSV_REPO}/UHDM-integration-tests/env/conda/envs/surelog_xc7/bin/symbiflow_synth", line 8, in <module>
    sys.exit(synth())
  File "${YSV_REPO}/UHDM-integration-tests/env/conda/envs/surelog_xc7/lib/python3.10/site-packages/f4pga/wrappers/sh/__init__.py", line 569, in synth
    p_run_sh_script(ROOT / SH_SUBDIR / "synth.f4pga.sh", env=env)
  File "${YSV_REPO}/UHDM-integration-tests/env/conda/envs/surelog_xc7/lib/python3.10/site-packages/f4pga/wrappers/sh/__init__.py", line 51, in p_run_sh_script
    check_call([str(script)] + sys_argv[1:], env=env)
  File "${YSV_REPO}/UHDM-integration-tests/env/conda/envs/surelog_xc7/lib/python3.10/subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '[
    '${YSV_REPO}/UHDM-integration-tests/env/conda/envs/surelog_xc7/lib/python3.10/site-packages/f4pga/wrappers/sh/xc7/synth.f4pga.sh',
    '-t', 'top_artya7',
    '-s',
    ' --disable-feature=parametersubstitution -parse -DSYNTHESIS  -PSRAMInitFile=${YSV_REPO}/UHDM-integration-tests/../uhdm-tests/ibex//led.vmem +define+PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx  -I../src/lowrisc_dv_crypto_prince_ref_0.1 -I../src/lowrisc_dv_dv_fcov_macros_0 -I../src/lowrisc_dv_secded_enc_0 -I../src/lowrisc_prim_assert_0.1/rtl -I../src/lowrisc_prim_util_get_scramble_params_0/rtl -I../src/lowrisc_prim_util_memload_0/rtl -I../src/lowrisc_dv_scramble_model_0 -I../src/lowrisc_dv_verilator_memutil_dpi_0/cpp -I../src/lowrisc_dv_verilator_memutil_dpi_scrambled_0/cpp -I../src/lowrisc_ibex_ibex_core_0.1/rtl',
    '-v',
    '../src/lowrisc_ibex_ibex_pkg_0.1/rtl/ibex_pkg.sv',
    '../src/lowrisc_prim_abstract_prim_pkg_0.1/prim_pkg.sv',
    '../src/lowrisc_prim_cipher_pkg_0.1/rtl/prim_cipher_pkg.sv',
    '../src/lowrisc_prim_generic_buf_0/rtl/prim_generic_buf.sv',
    '../src/lowrisc_prim_generic_clock_gating_0/rtl/prim_generic_clock_gating.sv',
    '../src/lowrisc_prim_generic_flop_0/rtl/prim_generic_flop.sv',
    '../src/lowrisc_prim_ram_1p_pkg_0/rtl/prim_ram_1p_pkg.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_pkg.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_22_16_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_22_16_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_28_22_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_28_22_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_39_32_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_39_32_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_64_57_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_64_57_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_72_64_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_72_64_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_hamming_22_16_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_hamming_22_16_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_hamming_39_32_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_hamming_39_32_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_hamming_72_64_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_hamming_72_64_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_hamming_76_68_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_hamming_76_68_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_22_16_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_22_16_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_28_22_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_28_22_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_39_32_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_39_32_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_64_57_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_64_57_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_72_64_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_72_64_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_hamming_22_16_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_hamming_22_16_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_hamming_39_32_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_hamming_39_32_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_hamming_72_64_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_hamming_72_64_enc.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_hamming_76_68_dec.sv',
    '../src/lowrisc_prim_secded_0.1/rtl/prim_secded_inv_hamming_76_68_enc.sv',
    '../src/lowrisc_prim_xilinx_buf_0/rtl/prim_xilinx_buf.sv',
    '../src/lowrisc_prim_xilinx_clock_gating_0/rtl/prim_xilinx_clock_gating.sv',
    '../src/lowrisc_prim_xilinx_clock_mux2_0/rtl/prim_xilinx_clock_mux2.sv',
    '../src/lowrisc_prim_xilinx_flop_0/rtl/prim_xilinx_flop.sv',
    '../src/lowrisc_ibex_ibex_icache_0.1/rtl/ibex_icache.sv',
    '../src/lowrisc_prim_cipher_0/rtl/prim_subst_perm.sv',
    '../src/lowrisc_prim_cipher_0/rtl/prim_present.sv',
    '../src/lowrisc_prim_cipher_0/rtl/prim_prince.sv',
    '../src/lowrisc_prim_generic_clock_mux2_0/rtl/prim_generic_clock_mux2.sv',
    '../src/lowrisc_prim_generic_ram_1p_0/rtl/prim_generic_ram_1p.sv',
    '../src/lowrisc_prim_lfsr_0.1/rtl/prim_lfsr.sv',
    '../src/lowrisc_prim_util_0.1/rtl/prim_util_pkg.sv',
    '../src/lowrisc_prim_abstract_buf_0/prim_buf.sv',
    '../src/lowrisc_prim_abstract_clock_gating_0/prim_clock_gating.sv',
    '../src/lowrisc_prim_abstract_clock_mux2_0/prim_clock_mux2.sv',
    '../src/lowrisc_prim_abstract_flop_0/prim_flop.sv',
    '../src/lowrisc_prim_badbit_ram_1p_0/prim_badbit_ram_1p.sv',
    '../src/lowrisc_prim_onehot_check_0/rtl/prim_onehot_check.sv',
    '../src/lowrisc_prim_abstract_ram_1p_0/prim_ram_1p.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_alu.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_branch_predict.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_compressed_decoder.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_controller.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_cs_registers.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_csr.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_counter.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_decoder.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_ex_block.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_fetch_fifo.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_if_stage.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_load_store_unit.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_multdiv_fast.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_multdiv_slow.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_prefetch_buffer.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_pmp.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_wb_stage.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_dummy_instr.sv',
    '../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_core.sv',
    '../src/lowrisc_ibex_fpga_xilinx_shared_0/rtl/fpga/xilinx/clkgen_xil7series.sv',
    '../src/lowrisc_ibex_fpga_xilinx_shared_0/rtl/ram_1p.sv',
    '../src/lowrisc_prim_ram_1p_adv_0.1/rtl/prim_ram_1p_adv.sv',
    '../src/lowrisc_prim_ram_1p_scr_0.1/rtl/prim_ram_1p_scr.sv',
    '../src/lowrisc_ibex_ibex_top_0.1/rtl/ibex_register_file_ff.sv',
    '../src/lowrisc_ibex_ibex_top_0.1/rtl/ibex_register_file_fpga.sv',
    '../src/lowrisc_ibex_ibex_top_0.1/rtl/ibex_register_file_latch.sv',
    '../src/lowrisc_ibex_ibex_top_0.1/rtl/ibex_lockstep.sv',
    '../src/lowrisc_ibex_ibex_top_0.1/rtl/ibex_top.sv',
    '../src/lowrisc_ibex_top_artya7_surelog_0.1/rtl/top_artya7.sv',
    '-d', 'artix7',
    '-p', 'xc7a35tcsg324-1',
    '-x', '../src/lowrisc_ibex_top_artya7_surelog_0.1/data/pins_artya7.xdc'
]' returned non-zero exit status 1.
```

It builds fine with the fix from this PR.

[ysv-ibex-makefile]: https://github.com/antmicro/yosys-systemverilog/blob/b3e7842db04ac26fc9e9d5cf33be1921cdc4083a/uhdm-tests/ibex/Makefile.in#L28-L120
