### PR TITLE
add arty s7 board and a counter example for it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,7 @@ add_dependencies(all_xc7_demos
     #all_zybo_bin
     all_zybo-full_bin
     all_ax7050_bin
+    all_arty-s7_bin
     )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repo contains documentation of various FPGA architectures, it is currently 
   * [iCE40](lattice/ice40)
   * [ECP5](lattice/ecp5)
 * AMD/Xilinx
-  * [Series 7](xilinx/xc7) (Artix, Kintex and Zynq)
+  * [Series 7](xilinx/xc7) (Artix, Kintex, Zynq and Spartan)
 * [QuickLogic](quicklogic)
 
 It includes:

--- a/xilinx/xc7/archs/spartan7/CMakeLists.txt
+++ b/xilinx/xc7/archs/spartan7/CMakeLists.txt
@@ -3,7 +3,7 @@ project_ray_prepare_database(
   PRJRAY_DIR ${PRJXRAY_DIR}
   PRJRAY_DB_DIR ${PRJXRAY_DB_DIR}
   PROTOTYPE_PART xc7s50fgga484-1
-  PARTS xc7s50fgga484-1
+  PARTS xc7s50fgga484-1 xc7s50csga324-1
 )
 
 set(ARCH spartan7)

--- a/xilinx/xc7/boards.cmake
+++ b/xilinx/xc7/boards.cmake
@@ -188,3 +188,9 @@ add_xc_board(
   PART xc7s50fgga484-1
 )
 
+add_xc_board(
+  BOARD arty-s7
+  DEVICE xc7s50
+  PACKAGE test
+  PART xc7s50csga324-1
+)

--- a/xilinx/xc7/tests/counter/CMakeLists.txt
+++ b/xilinx/xc7/tests/counter/CMakeLists.txt
@@ -190,3 +190,13 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
 )
 
+
+add_file_target(FILE counter_arty_s7.xdc)
+add_file_target(FILE counter_arty_s7.v SCANNER_TYPE verilog)
+add_fpga_target(
+  NAME counter_arty_s7
+  BOARD arty-s7
+  SOURCES counter.v
+  INPUT_XDC_FILES counter_arty_s7.xdc
+  EXPLICIT_ADD_FILE_TARGET
+)

--- a/xilinx/xc7/tests/counter/counter_arty_s7.v
+++ b/xilinx/xc7/tests/counter/counter_arty_s7.v
@@ -1,0 +1,15 @@
+module top (
+    input  wire clk,
+    output wire [3:0] led
+);
+    localparam BITS = 8;
+    localparam LOG2DELAY = 22;
+
+    reg [BITS+LOG2DELAY-1:0] counter = 0;
+
+    always @(posedge clk) begin
+    	counter <= counter + 1;
+    end
+
+    assign led = counter >> LOG2DELAY;
+endmodule

--- a/xilinx/xc7/tests/counter/counter_arty_s7.xdc
+++ b/xilinx/xc7/tests/counter/counter_arty_s7.xdc
@@ -1,0 +1,14 @@
+set_property -dict { PACKAGE_PIN R2    IOSTANDARD SSTL135 } [get_ports { clk }]; #IO_L12P_T1_MRCC_34 Sch=ddr3_clk[200]
+create_clock -add -name sys_clk_pin -period 10.000 -waveform {0 5.000}  [get_ports { clk }];
+
+set_property -dict { PACKAGE_PIN E18   IOSTANDARD LVCMOS33 } [get_ports { led[0] }]; #IO_L16N_T2_A27_15 Sch=led[2]
+set_property -dict { PACKAGE_PIN F13   IOSTANDARD LVCMOS33 } [get_ports { led[1] }]; #IO_L17P_T2_A26_15 Sch=led[3]
+set_property -dict { PACKAGE_PIN E13   IOSTANDARD LVCMOS33 } [get_ports { led[2] }]; #IO_L17N_T2_A25_15 Sch=led[4]
+set_property -dict { PACKAGE_PIN H15   IOSTANDARD LVCMOS33 } [get_ports { led[3] }]; #IO_L18P_T2_A24_15 Sch=led[5]
+
+set_property BITSTREAM.CONFIG.CONFIGRATE 50 [current_design]
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property CFGBVS VCCO [current_design]
+set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]
+set_property CONFIG_MODE SPIx4 [current_design]
+set_property INTERNAL_VREF 0.675 [get_iobanks 34]


### PR DESCRIPTION
I've basically added arty s7 board by extending [what @liibin has done for ax7050](https://github.com/f4pga/f4pga-arch-defs/pull/2658) and the counter example worked just fine.
After copying the newly generated arty s7 pinmap, which was in `path/to/f4pga-arch-defs/build/xilinx/xc7/arty-s7_pinmap.csv`, to `$F4PGA_DIR/xc7/share/f4pga/arch/xc7s50_test/xc7s50csga324-1/pinmap.csv` I was even able to build the counter example outside this repo
using the [common.mk from f4pga-examples](https://github.com/chipsalliance/f4pga-examples/blob/main/common/common.mk).
